### PR TITLE
Various fixes for later Java and Jenkins versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.2</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>3.50</version><!-- which version of Jenkins is this plugin built against? -->
     <relativePath />
   </parent>
 
@@ -35,18 +35,10 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.7.1</jenkins.version>
-    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
-    <java.level>7</java.level>
-    <!-- Jenkins Test Harness version you use to test the plugin. -->
-    <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-    <!-- <jenkins-test-harness.version>2.13</jenkins-test-harness.version> -->
-    <!-- Other properties you may want to use:
-        ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
-        ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
-    -->
+    <jenkins.version>2.164.3</jenkins.version>
+    <java.level>8</java.level>
     <jmockit.version>1.38</jmockit.version>
-    <amqp.client.version>3.4.1</amqp.client.version>
+    <amqp.client.version>5.6.0</amqp.client.version>
     <commons.validator.version>1.6</commons.validator.version>
     <commons.digester.version>2.1</commons.digester.version>
     <commons.lang3.version>3.7</commons.lang3.version>
@@ -89,11 +81,19 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>
+            -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
+          </argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>8</source>
+          <target>8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -113,13 +113,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <configuration>
-          <defaultPort>8091</defaultPort>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqconsumer/GlobalRabbitmqConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqconsumer/GlobalRabbitmqConfiguration.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 import javax.servlet.ServletException;
 
@@ -293,7 +294,7 @@ public final class GlobalRabbitmqConfiguration extends GlobalConfiguration {
                 return FormValidation.error(Messages.Error() + ": " + e);
             } catch (PossibleAuthenticationFailureException e) {
                 return FormValidation.error(Messages.AuthFailure());
-            } catch (IOException e) {
+            } catch (IOException | TimeoutException e) {
                 return FormValidation.error(Messages.Error() + ": " + e);
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqconsumer/RMQConnection.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqconsumer/RMQConnection.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.rabbitmqconsumer.channels.AbstractRMQChannel;
@@ -361,7 +362,7 @@ public class RMQConnection implements ShutdownListener, RMQChannelListener, RMQC
                 if (!usedQueueNames.contains(ch.getQueueName())) {
                     try {
                         ch.close();
-                    } catch (IOException ex) {
+                    } catch (IOException | TimeoutException ex) {
                         unclosedChannels.add(ch);
                     }
                 }
@@ -384,7 +385,7 @@ public class RMQConnection implements ShutdownListener, RMQChannelListener, RMQC
             for (AbstractRMQChannel h : rmqChannels) {
                 try {
                     h.close();
-                } catch (IOException ex) {
+                } catch (IOException | TimeoutException ex) {
                     unclosedChannels.add(h);
                 }
             }
@@ -407,7 +408,7 @@ public class RMQConnection implements ShutdownListener, RMQChannelListener, RMQC
             for (ConsumeRMQChannel h : channels) {
                 try {
                     h.close();
-                } catch (IOException ex) {
+                } catch (IOException | TimeoutException ex) {
                     unclosedChannels.add(h);
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqconsumer/channels/AbstractRMQChannel.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqconsumer/channels/AbstractRMQChannel.java
@@ -75,10 +75,12 @@ public abstract class AbstractRMQChannel implements RMQChannelNotifier, Shutdown
         return channel;
     }
 
+
     /**
      * Close channel.
-     *
-     * @throws IOException throws if something error.
+     * 
+     * @throws IOException
+     * @throws TimeoutException
      */
     public void close() throws IOException, TimeoutException {
         if (state == RMQState.CONNECTED) {

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqconsumer/channels/AbstractRMQChannel.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqconsumer/channels/AbstractRMQChannel.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.rabbitmqconsumer.channels;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeoutException;
 
 import org.jenkinsci.plugins.rabbitmqconsumer.RMQState;
 import org.jenkinsci.plugins.rabbitmqconsumer.events.RMQChannelEvent;
@@ -79,13 +80,13 @@ public abstract class AbstractRMQChannel implements RMQChannelNotifier, Shutdown
      *
      * @throws IOException throws if something error.
      */
-    public void close() throws IOException {
+    public void close() throws IOException, TimeoutException {
         if (state == RMQState.CONNECTED) {
             if (channel != null) {
                 try {
                     state = RMQState.CLOSE_PENDING;
                     channel.close();
-                } catch (IOException ex) {
+                } catch (IOException | TimeoutException ex) {
                     LOGGER.warn("Failed to close channel.");
                     if (!(ex.getCause() instanceof ShutdownSignalException)) {
                         state = RMQState.DISCONNECTED;


### PR DESCRIPTION
Old versions of the amqp-client lib raises exceptions with
latest Java 8 version. Probably due to sharpened policies
on how tls certs are handled:

javax.net.ssl.SSLHandshakeException: No appropriate protocol
  (protocol is disabled or cipher suites are inappropriate)

Fix by updating amqp-client to 5.6.0, same version as used by
the eiffel & mq-notifier-plugin.

+ Introduce pom fixes to allow surefire to run with jmockit.
+ Upgrade plugin parent to 3.50 and needed java version to 8.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
